### PR TITLE
Fix crash in SetCursorPosition

### DIFF
--- a/Game/FrameBuffer.cs
+++ b/Game/FrameBuffer.cs
@@ -21,15 +21,16 @@ unsafe struct FrameBuffer
 
     public readonly void Render()
     {
-        Console.SetCursorPosition(0, 0);
-
         const ConsoleColor snakeColor = ConsoleColor.Green;
 
         Console.ForegroundColor = snakeColor;
 
-        for (int i = 1; i <= Area; i++)
+        for (int i = 0; i < Area; i++)
         {
-            char c = _chars[i - 1];
+            if (i % Width == 0)
+                Console.SetCursorPosition(0, i / Width);
+
+            char c = _chars[i];
 
             if (c == '*' || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z'))
             {
@@ -39,11 +40,6 @@ unsafe struct FrameBuffer
             }
             else
                 Console.Write(c);
-
-            if (i % Width == 0)
-            {
-                Console.SetCursorPosition(0, i / Width);
-            }
         }
     }
 }

--- a/Game/Game.cs
+++ b/Game/Game.cs
@@ -91,8 +91,8 @@ struct Game
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            Console.SetWindowSize(FrameBuffer.Width, FrameBuffer.Height);
-            Console.SetBufferSize(FrameBuffer.Width, FrameBuffer.Height);
+            Console.SetWindowSize(FrameBuffer.Width, FrameBuffer.Height + 1);
+            Console.SetBufferSize(FrameBuffer.Width, FrameBuffer.Height + 1);
             Console.Title = "See Sharp Snake";
             Console.CursorVisible = false;
         }


### PR DESCRIPTION
Fixes #17. The issue was introduced by #15, which started to call `Console.SetCursorPosition(0, 20)` after printing the bottom-right character. That position is just outside the buffer area. I changed the code to call `Console.SetCursorPosition(0, ...)` at the beginning of each line instead. That fixed the crash; however, I started to see the window scrolled up one line after the bottom-right character is printed. It seems the simplest fix to avoid scrolling is to add an extra (unused) line at the bottom of the window.