### PR TITLE
Fix publish of no-runtime examples

### DIFF
--- a/SeeSharpSnake.csproj
+++ b/SeeSharpSnake.csproj
@@ -71,6 +71,8 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <IlcSystemModule>SeeSharpSnake</IlcSystemModule>
+    <SelfContained>false</SelfContained>
+    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(Mode)' == 'CoreRT-NoRuntime'">


### PR DESCRIPTION
IIRC these changes started to be required around .NET 5, but maybe .NET 6